### PR TITLE
Syncing dev with v0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@habx/config-ci-front",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@habx/config-ci-front",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Configurations files for frontend repositories",
   "scripts": {},
   "repository": {


### PR DESCRIPTION
Fixes made in v0.0.2 should appear in the dev branch

-- 
_[create_release](https://github.com/habx/devops-job-release-tools) v0.16.2_
